### PR TITLE
Branch fast jump targets

### DIFF
--- a/addressof.inc
+++ b/addressof.inc
@@ -1,0 +1,66 @@
+// Copyright (C) 2016 Y_Less
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+#if defined ADDRESSOF_INC
+	#endinput
+#endif
+#define ADDRESSOF_INC
+
+#include "frame_info"
+#include "disasm"
+
+// This code uses two nested conditionals because of:
+// https://github.com/Zeex/pawn/issues/96 (this doesn't work):
+//   
+//   (O@A_() ? ((CALL@%1), 0) : (O@V_))
+//   
+// Even though it is the obvious solution when you don't want the result of
+// "CALL@%1" to be used (as it may not exist), and you can't use a constant
+// instead of "O@V_" because then if becomes a constant in a
+// condition, which the compiler rightly complains about.  Of course, because
+// "O@A_()" always returns "false", the entire other block of code
+// is jumped over.
+#define addressof(%1) (O@A_()?(((CALL@%1),O@V_)?1:2):(O@V_))
+
+#define gAddressOfReturnVar_ O@V_
+#define AddressOfGetNextCall_ O@A_
+#define CALL@AddressOfGetNextCall_ CALL@O@A_
+#define CALL@O@A_ O@A_()
+
+stock
+	gAddressOfReturnVar_ = 0;
+
+stock bool:AddressOfGetNextCall_() {
+	// Start reading code from the point to which this function returns, looking
+	// for the next "CALL" op to signal the function call from the macro.
+	new ctx[DisasmContext];
+	DisasmInit(ctx, GetCurrentFrameReturn());
+	while (DisasmNext(ctx)) {
+		if (DisasmGetOpcode(ctx) == OP_CALL) {
+			// Return the data in a global, to be repassed from the conditional.
+			gAddressOfReturnVar_ = DisasmGetOperandReloc(ctx);
+			return false;
+		}
+	}
+	// ALWAYS returns false so that the function call within "OP(&func)" will
+	// never be called thanks to the conditional.
+	return false;
+}
+

--- a/amx_jit.inc
+++ b/amx_jit.inc
@@ -40,3 +40,13 @@ stock GetAmxJITBaseAddress() {
 	return 0;
 }
 
+stock ResolveJITAddress(addr) {
+	// Converts an address to a JIT address, if there is a JIT.  Otherwise does
+	// nothing.  Could make it try detect if this is already JIT resolved, i.e.
+	// is a return address.
+	#emit load.s.pri addr
+	#emit lctrl 8
+	#emit retn
+	return 0;
+}
+

--- a/amx_memory.inc
+++ b/amx_memory.inc
@@ -33,10 +33,33 @@ stock ref(...) {
 	return 0; // make compiler happy
 }
 
+// Returns an array from an address.
 stock deref(v) {
-	#pragma unused v
 	static gFake[1];
-	#emit load.s.pri 12 // first argument
+	#emit load.s.pri  v // first argument
+	#emit stor.s.pri 16 // secret argument
+	#emit retn
+	return gFake; // make compiler happy
+}
+
+// Returns the address of a variable parameter.
+stock argref(n) {
+	#emit load.s.alt 0
+	#emit load.s.pri n
+	#emit add.c 3
+	#emit lidx
+	#emit retn
+	return 0; // make compiler happy
+}
+
+// Returns an array from a variable parameter.
+stock argderef(n) {
+	static gFake[1];
+	
+	#emit load.s.alt 0
+	#emit load.s.pri n
+	#emit add.c 3
+	#emit lidx
 	#emit stor.s.pri 16 // secret argument
 	#emit retn
 	return gFake; // make compiler happy

--- a/amx_memory.inc
+++ b/amx_memory.inc
@@ -170,7 +170,7 @@ stock SetAmxStackBottom(ptr)
 	#emit sctrl 4
 	// Return.
 	#emit load.pri cip
-	#emit lctrl 8
+	#emit sctrl 8
 	#emit sctrl 6
 }
 
@@ -185,7 +185,7 @@ stock SetAmxFrame(ptr)
 	// Return.
 	#emit move.pri
 	#emit stack 16
-	#emit lctrl 8
+	#emit sctrl 8
 	#emit sctrl 6
 }
 
@@ -198,7 +198,7 @@ stock SetAmxNextInstructionPointer(ptr)
 	// Return.
 	#emit move.pri
 	#emit stack 16
-	#emit lctrl 8
+	#emit sctrl 8
 	#emit sctrl 6
 }
 

--- a/asm.inc
+++ b/asm.inc
@@ -155,7 +155,8 @@ stock AsmError:AsmEmitLabelStringize(ctx[AsmContext], const label[]) {
 			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
 		}
 		ctx[AsmContext_label_names][idx] = hash;
-	} else if (AsmIsLabelResolved(ctx, idx)) {
+	}
+	if (AsmIsLabelResolved(ctx, idx)) {
 		// Check that no other labels have the same name.
 		return AsmRaiseError(ctx, ASM_ERROR_LABEL_DUPLICATE);
 	} else {
@@ -189,7 +190,8 @@ stock AsmError:AsmEmitJumpStringize(ctx[AsmContext], const label[], bool:relativ
 			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
 		}
 		ctx[AsmContext_label_names][idx] = hash;
-	} else if (AsmIsLabelResolved(ctx, idx)) {
+	}
+	if (AsmIsLabelResolved(ctx, idx)) {
 		// The label was in the past, jump to that.
 		new cur = AsmGetLabel(ctx, idx);
 		if (relative) {
@@ -207,7 +209,7 @@ stock AsmError:AsmEmitJumpStringize(ctx[AsmContext], const label[], bool:relativ
 		}
 		if (error == ASM_ERROR_NONE) {
 			// Store to the list only if the output was successful.
-			AsmSetLabel(ctx, idx, datAddr);
+			ctx[AsmContext_labels][idx] = datAddr;
 		}
 	}
 	return error;
@@ -588,6 +590,64 @@ stock AsmError:AsmEmitJzerRel(ctx[AsmContext], offset) {
 
 stock AsmError:AsmEmitJrel(ctx[AsmContext], offset) {
 	return AsmEmitInstruction(ctx, OP_JREL, offset);
+}
+
+stock AsmError:AsmEmitJeqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JEQ, label);
+}
+
+stock AsmError:AsmEmitJgeqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JGEQ, label);
+}
+
+stock AsmError:AsmEmitJgrtrLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JGRTR, label);
+}
+
+stock AsmError:AsmEmitJleqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JLEQ, label);
+}
+
+stock AsmError:AsmEmitJlessLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JLESS, label);
+}
+
+stock AsmError:AsmEmitJneqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JNEQ, label);
+}
+
+stock AsmError:AsmEmitJnzLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JNZ, label);
+}
+
+stock AsmError:AsmEmitJsgeqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JSGEQ, label);
+}
+
+stock AsmError:AsmEmitJsgrtrLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JSTRTR, label);
+}
+
+stock AsmError:AsmEmitJsleqLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JSLEQ, label);
+}
+
+stock AsmError:AsmEmitJslessLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JSLESS, label);
+}
+
+stock AsmError:AsmEmitJumpLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JUMP, label);
+}
+
+stock AsmError:AsmEmitJzerLabelStringize(ctx[AsmContext], const label[]) {
+	return AsmEmitJumpLabelInstruction(ctx, OP_JZER, label);
+}
+
+stock AsmError:AsmEmitJrelLabelStringize(ctx[AsmContext], const label[]) {
+	// Despite the name, once compiled this is no longer relative.  Use the
+	// `relative = false` parameter just to make this extra explicit.
+	return AsmEmitJumpLabelInstruction(ctx, OP_JREL, label, false);
 }
 
 stock AsmError:AsmEmitLctrl(ctx[AsmContext], index) {

--- a/asm.inc
+++ b/asm.inc
@@ -30,11 +30,17 @@
 #include "dynamic_call"
 #include "opcode"
 
+#if !defined ASM_MAX_LABELS
+	#define ASM_MAX_LABELS (8)
+#endif
+
 enum AsmError {
 	ASM_ERROR_NONE,
 	ASM_ERROR_OPCODE,
 	ASM_ERROR_OPERAND,
 	ASM_ERROR_SPACE,
+	ASM_ERROR_LABEL_OVERFLOW,
+	ASM_ERROR_LABEL_DUPLICATE,
 };
 
 enum AsmContext {
@@ -43,6 +49,23 @@ enum AsmContext {
 	AsmContext_buffer_offset,
 	AsmContext_error,
 	AsmContext_error_handler,  // ErrorHandler(ctx[AsmContext])
+	AsmContext_label_names[ASM_MAX_LABELS],
+	// All labels in PAWN should be 4-byte-aligned (1 cell in 32-bit).  This
+	// means the bottom two bits are always `0b00`.  We re-use this data to
+	// store two bits of information - is this label resolved (i.e. do we know
+	// the true address yet), and is this use of the label relative or absolute?
+	// 
+	// If the label is NOT resolved, the current value is the start pointer of a
+	// linked list of jump-ahead uses of the label (relative to DAT), i.e. jumps
+	// waiting to know the label's address when it is eventually defined.  If
+	// the label IS resolved, it is just the absolute address of the label
+	// (relative to COD) so that any new uses can be resolved instantly.  The
+	// lowest bit determines which.
+	// 
+	// If a jump to an unknown label is emitted, the value is the next item in
+	// the linked list (potentially NULL), and the bottom bit is instead used to
+	// determine which jump type this is - relative (1) or absolute (0).
+	AsmContext_labels[ASM_MAX_LABELS],
 };
 
 stock const ASM_ARGUMENTS_OFFSET    =  0x0C;
@@ -142,6 +165,10 @@ stock AsmError:AsmInitPtr(ctx[AsmContext], buffer, size) {
 	ctx[AsmContext_buffer_size] = size;
 	ctx[AsmContext_buffer_offset] = 0;
 	ctx[AsmContext_error_handler] = 0;
+	for (new i = 0; i != ASM_MAX_LABELS; ++i) {
+		ctx[AsmContext_label_names][i] = 0;
+		ctx[AsmContext_labels][i] = 0;
+	}
 	return ASM_ERROR_NONE;
 }
 
@@ -190,6 +217,107 @@ stock AsmError:AsmSetErrorHandler(ctx[AsmContext], error_handler) {
 
 stock AsmError:AsmSetErrorHandlerName(ctx[AsmContext], error_handler[]) {
 	ctx[AsmContext_error_handler] = GetPublicAddressFromName(error_handler);
+	return ASM_ERROR_NONE;
+}
+
+// Label functions:
+
+#define AsmIsLabelResolved(%2,%0)    (%2[AsmContext_labels][(%0)] & 1)
+#define AsmIsJumpRelative(%0)        ((%0) & 1)
+#define AsmSetJumpRelative(%2,%0,%1) (%2[AsmContext_labels][(%0)] & (%1))
+#define AsmGetLabel(%2,%0)           (%2[AsmContext_labels][(%0)] & ~1)
+#define AsmSetLabel(%2,%0,%1)        (%2[AsmContext_labels][(%0)] = (%1) | 1)
+
+static stock AsmHashLabel(const label[]) {
+	// Return the Bernstein hash of this label.  This is NOT a cryptographically
+	// secure hash, but is sufficient for our uses.
+	new hash = -1;
+	new i = -1;
+	new ch;
+	while ((ch = label[++i])) {
+		hash = hash * 33 + ch;
+	}
+	return hash;
+}
+
+static stock AsmFindLabelIndex(ctx[AsmContext], hash) {
+	for (new i = 0; i != ASM_MAX_LABELS; ++i) {
+		if (ctx[AsmContext_label_names][i] == hash) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+stock AsmEmitLabelStringize(ctx[AsmContext], const label[]) {
+	// Everything works on the hashes - it saves storing the strings.
+	new hash = AsmHashLabel(label);
+	// See if this label already exists.
+	new idx = AsmFindLabelIndex(ctx, hash);
+	// Get the true address.  Use an offset of -8 because
+	// `AsmGetJumpAddressFromOffset` assumes the jump is from the start of the
+	// next instruction (8 bytes later), while we want it from right here, so
+	// shift back accordingly.
+	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
+	new codAddr = AsmGetJumpAddressFromOffset(ctx, -8);
+	if (idx == -1) {
+		// Doesn't exist.  Get a free slot.
+		idx = AsmFindLabelIndex(ctx, 0);
+		if (idx == -1) {
+			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
+		}
+		ctx[AsmContext_label_names][idx] = hash;
+	} else if (AsmIsLabelResolved(ctx, idx)) {
+		// Check that no other labels have the same name.
+		return AsmRaiseError(ctx, ASM_ERROR_LABEL_DUPLICATE);
+	} else {
+		// Loop over all the pending items in the linked list.
+		new cur = AsmGetLabel(ctx, idx);
+		while (cur) {
+			new next = ReadAmxMemory(cur);
+			if (AsmIsJumpRelative(next)) {
+				WriteAmxMemory(cur, datAddr - cur - 4);
+			} else {
+				WriteAmxMemory(cur, codAddr);
+			}
+			cur = next & ~1;
+		}
+	}
+	// Store the label's absolute address, along with a flag to mark that it is
+	// resolved.
+	AsmSetLabel(ctx, idx, codAddr);
+	return ASM_ERROR_NONE;
+}
+
+stock AsmEmitJumpStringize(ctx[AsmContext], const label[], bool:relative) {
+	new hash = AsmHashLabel(label);
+	new idx = AsmFindLabelIndex(ctx, hash);
+	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
+	if (idx == -1) {
+		// Doesn't exist.  Get a free slot.
+		idx = AsmFindLabelIndex(ctx, 0);
+		if (idx == -1) {
+			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
+		}
+		ctx[AsmContext_label_names][idx] = hash;
+	} else if (AsmIsLabelResolved(ctx, idx)) {
+		// The label was in the past, jump to that.
+		new cur = AsmGetLabel(ctx, idx);
+		if (relative) {
+			AsmEmitCell(ctx, cur - datAddr - 4);
+		} else {
+			AsmEmitCell(ctx, cur);
+		}
+	} else {
+		// The label is not yet known, store this use in the list.
+		new cur = AsmGetLabel(ctx, idx);
+		if (relative) {
+			AsmEmitCell(ctx, cur | 1);
+		} else {
+			AsmEmitCell(ctx, cur);
+		}
+		AsmSetLabel(ctx, idx, datAddr);
+	}
 	return ASM_ERROR_NONE;
 }
 

--- a/asm.inc
+++ b/asm.inc
@@ -108,6 +108,111 @@ static stock AsmError:AsmEmitCell(ctx[AsmContext], value) {
 	return ASM_ERROR_NONE;
 }
 
+// Label functions:
+
+#define AsmIsLabelResolved(%2,%0)    (%2[AsmContext_labels][(%0)] & 1)
+#define AsmIsJumpRelative(%0)        ((%0) & 1)
+#define AsmSetJumpRelative(%2,%0,%1) (%2[AsmContext_labels][(%0)] & (%1))
+#define AsmGetLabel(%2,%0)           (%2[AsmContext_labels][(%0)] & ~1)
+#define AsmSetLabel(%2,%0,%1)        (%2[AsmContext_labels][(%0)] = (%1) | 1)
+
+static stock AsmHashLabel(const label[]) {
+	// Return the Bernstein hash of this label.  This is NOT a cryptographically
+	// secure hash, but is sufficient for our uses.
+	new hash = -1;
+	new i = -1;
+	new ch;
+	while ((ch = label[++i])) {
+		hash = hash * 33 + ch;
+	}
+	return hash;
+}
+
+static stock AsmFindLabelIndex(ctx[AsmContext], hash) {
+	for (new i = 0; i != ASM_MAX_LABELS; ++i) {
+		if (ctx[AsmContext_label_names][i] == hash) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+stock AsmError:AsmEmitLabelStringize(ctx[AsmContext], const label[]) {
+	// Everything works on the hashes - it saves storing the strings.
+	new hash = AsmHashLabel(label);
+	// See if this label already exists.
+	new idx = AsmFindLabelIndex(ctx, hash);
+	// Get the true address.  Use an offset of -8 because
+	// `AsmGetJumpAddressFromOffset` assumes the jump is from the start of the
+	// next instruction (8 bytes later), while we want it from right here, so
+	// shift back accordingly.
+	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
+	new codAddr = AsmGetJumpAddressFromOffset(ctx, -8);
+	if (idx == -1) {
+		// Doesn't exist.  Get a free slot.
+		idx = AsmFindLabelIndex(ctx, 0);
+		if (idx == -1) {
+			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
+		}
+		ctx[AsmContext_label_names][idx] = hash;
+	} else if (AsmIsLabelResolved(ctx, idx)) {
+		// Check that no other labels have the same name.
+		return AsmRaiseError(ctx, ASM_ERROR_LABEL_DUPLICATE);
+	} else {
+		// Loop over all the pending items in the linked list.
+		new cur = AsmGetLabel(ctx, idx);
+		while (cur) {
+			new next = ReadAmxMemory(cur);
+			if (AsmIsJumpRelative(next)) {
+				WriteAmxMemory(cur, datAddr - cur - 4);
+			} else {
+				WriteAmxMemory(cur, codAddr);
+			}
+			cur = next & ~1;
+		}
+	}
+	// Store the label's absolute address, along with a flag to mark that it is
+	// resolved.
+	AsmSetLabel(ctx, idx, codAddr);
+	return ASM_ERROR_NONE;
+}
+
+stock AsmError:AsmEmitJumpStringize(ctx[AsmContext], const label[], bool:relative) {
+	new hash = AsmHashLabel(label);
+	new idx = AsmFindLabelIndex(ctx, hash);
+	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
+	new AsmError:error = ASM_ERROR_NONE;
+	if (idx == -1) {
+		// Doesn't exist.  Get a free slot.
+		idx = AsmFindLabelIndex(ctx, 0);
+		if (idx == -1) {
+			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
+		}
+		ctx[AsmContext_label_names][idx] = hash;
+	} else if (AsmIsLabelResolved(ctx, idx)) {
+		// The label was in the past, jump to that.
+		new cur = AsmGetLabel(ctx, idx);
+		if (relative) {
+			error = AsmEmitCell(ctx, cur - datAddr - 4);
+		} else {
+			error = AsmEmitCell(ctx, cur);
+		}
+	} else {
+		// The label is not yet known, store this use in the list.
+		new cur = AsmGetLabel(ctx, idx);
+		if (relative) {
+			error = AsmEmitCell(ctx, cur | 1);
+		} else {
+			error = AsmEmitCell(ctx, cur);
+		}
+		if (error == ASM_ERROR_NONE) {
+			// Store to the list only if the output was successful.
+			AsmSetLabel(ctx, idx, datAddr);
+		}
+	}
+	return error;
+}
+
 // Core functions:
 
 stock AsmError:AsmEmitOpcode(ctx[AsmContext], Opcode:opcode) {
@@ -158,6 +263,19 @@ stock AsmGetJumpAddressFromOffset(ctx[AsmContext], offset) {
 
 stock AsmError:AsmEmitJumpInstruction(ctx[AsmContext], Opcode:opcode, offset) {
 	return AsmEmitInstruction(ctx, opcode, AsmGetJumpAddressFromOffset(ctx, offset));
+}
+
+stock AsmError:AsmEmitJumpLabelInstruction(ctx[AsmContext], Opcode:opcode, const label[], bool:relative = false) {
+	// if there's an error while writing then backtracking is useful
+	gPreviousWriteOffset = ctx[AsmContext_buffer_offset];
+
+	new AsmError:error = ASM_ERROR_NONE;
+
+	error = AsmEmitOpcode(ctx, opcode);
+	if (error != ASM_ERROR_NONE) {
+		return error;
+	}
+	return AsmEmitJumpStringize(ctx, label, relative);
 }
 
 stock AsmError:AsmInitPtr(ctx[AsmContext], buffer, size) {
@@ -217,107 +335,6 @@ stock AsmError:AsmSetErrorHandler(ctx[AsmContext], error_handler) {
 
 stock AsmError:AsmSetErrorHandlerName(ctx[AsmContext], error_handler[]) {
 	ctx[AsmContext_error_handler] = GetPublicAddressFromName(error_handler);
-	return ASM_ERROR_NONE;
-}
-
-// Label functions:
-
-#define AsmIsLabelResolved(%2,%0)    (%2[AsmContext_labels][(%0)] & 1)
-#define AsmIsJumpRelative(%0)        ((%0) & 1)
-#define AsmSetJumpRelative(%2,%0,%1) (%2[AsmContext_labels][(%0)] & (%1))
-#define AsmGetLabel(%2,%0)           (%2[AsmContext_labels][(%0)] & ~1)
-#define AsmSetLabel(%2,%0,%1)        (%2[AsmContext_labels][(%0)] = (%1) | 1)
-
-static stock AsmHashLabel(const label[]) {
-	// Return the Bernstein hash of this label.  This is NOT a cryptographically
-	// secure hash, but is sufficient for our uses.
-	new hash = -1;
-	new i = -1;
-	new ch;
-	while ((ch = label[++i])) {
-		hash = hash * 33 + ch;
-	}
-	return hash;
-}
-
-static stock AsmFindLabelIndex(ctx[AsmContext], hash) {
-	for (new i = 0; i != ASM_MAX_LABELS; ++i) {
-		if (ctx[AsmContext_label_names][i] == hash) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-stock AsmEmitLabelStringize(ctx[AsmContext], const label[]) {
-	// Everything works on the hashes - it saves storing the strings.
-	new hash = AsmHashLabel(label);
-	// See if this label already exists.
-	new idx = AsmFindLabelIndex(ctx, hash);
-	// Get the true address.  Use an offset of -8 because
-	// `AsmGetJumpAddressFromOffset` assumes the jump is from the start of the
-	// next instruction (8 bytes later), while we want it from right here, so
-	// shift back accordingly.
-	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
-	new codAddr = AsmGetJumpAddressFromOffset(ctx, -8);
-	if (idx == -1) {
-		// Doesn't exist.  Get a free slot.
-		idx = AsmFindLabelIndex(ctx, 0);
-		if (idx == -1) {
-			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
-		}
-		ctx[AsmContext_label_names][idx] = hash;
-	} else if (AsmIsLabelResolved(ctx, idx)) {
-		// Check that no other labels have the same name.
-		return AsmRaiseError(ctx, ASM_ERROR_LABEL_DUPLICATE);
-	} else {
-		// Loop over all the pending items in the linked list.
-		new cur = AsmGetLabel(ctx, idx);
-		while (cur) {
-			new next = ReadAmxMemory(cur);
-			if (AsmIsJumpRelative(next)) {
-				WriteAmxMemory(cur, datAddr - cur - 4);
-			} else {
-				WriteAmxMemory(cur, codAddr);
-			}
-			cur = next & ~1;
-		}
-	}
-	// Store the label's absolute address, along with a flag to mark that it is
-	// resolved.
-	AsmSetLabel(ctx, idx, codAddr);
-	return ASM_ERROR_NONE;
-}
-
-stock AsmEmitJumpStringize(ctx[AsmContext], const label[], bool:relative) {
-	new hash = AsmHashLabel(label);
-	new idx = AsmFindLabelIndex(ctx, hash);
-	new datAddr = ctx[AsmContext_buffer] + ctx[AsmContext_buffer_offset];
-	if (idx == -1) {
-		// Doesn't exist.  Get a free slot.
-		idx = AsmFindLabelIndex(ctx, 0);
-		if (idx == -1) {
-			return AsmRaiseError(ctx, ASM_ERROR_LABEL_OVERFLOW);
-		}
-		ctx[AsmContext_label_names][idx] = hash;
-	} else if (AsmIsLabelResolved(ctx, idx)) {
-		// The label was in the past, jump to that.
-		new cur = AsmGetLabel(ctx, idx);
-		if (relative) {
-			AsmEmitCell(ctx, cur - datAddr - 4);
-		} else {
-			AsmEmitCell(ctx, cur);
-		}
-	} else {
-		// The label is not yet known, store this use in the list.
-		new cur = AsmGetLabel(ctx, idx);
-		if (relative) {
-			AsmEmitCell(ctx, cur | 1);
-		} else {
-			AsmEmitCell(ctx, cur);
-		}
-		AsmSetLabel(ctx, idx, datAddr);
-	}
 	return ASM_ERROR_NONE;
 }
 

--- a/asm_macros.inc
+++ b/asm_macros.inc
@@ -25,14 +25,15 @@
 
 // Only detect ONE space, so you don't need a trailing space on opcodes with no
 // parameters. Add a space on the end here incase there wasn't one already.
-#define @emit%0\32;%1\10;%3 (asm_emit_label:asm_emit_notlabel:asm_emit_(ctx,%1));
+#define @emit%0\32;%1\10;%3 (asm_emit_haslabel:asm_emit_notlabel:asm_emit_(ctx,%1));
 
 // Detect labels (for jump targets).
-#define asm_emit_label:asm_emit_notlabel:asm_emit_(ctx,%1:) AsmEmitLabel(ctx,#%1)
+#define asm_emit_haslabel:asm_emit_notlabel:asm_emit_(ctx,%1:) AsmEmitLabelStringize AsmEmitLabel:(ctx,%1)
 #define asm_emit_notlabel:asm_emit_(ctx,%1) asm_emit_(ctx,%1 )
 
 // Detect jumps to labels, instead of the labels themselves.
-#define AsmEmitLabel(ctx,#%1\32;%2) asm_emit_%1Label(ctx,%2)
+#define AsmEmitLabelStringize%0:(ctx,%1\32;%2) asm_emit_%1Label(ctx,%2)
+#define AsmEmitLabel:(ctx,%2) (ctx,#%2)
 
 // NOW detect the second space and use it to extract the opcode name.
 #define asm_emit_(ctx,%1\32;%2) asm_emit_%1(ctx,%2)
@@ -737,4 +738,12 @@
 #define AsmEmitCallLABELLabel AsmEmitCallLabel
 #define AsmEmitCallLabelLabel AsmEmitCallLabel
 #define AsmEmitCallLabel(ctx,%2) AsmEmitCallLabelStringize(ctx,#%2)
+
+// Explicit `@emit Label name`
+#define asm_emit_labelLabel(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
+#define asm_emit_LABELLabel(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
+#define asm_emit_LabelLabel(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
+#define asm_emit_label(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
+#define asm_emit_LABEL(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
+#define asm_emit_Label(ctx,%2) AsmEmitLabelStringize(ctx,#%2)
 

--- a/asm_macros.inc
+++ b/asm_macros.inc
@@ -25,9 +25,18 @@
 
 // Only detect ONE space, so you don't need a trailing space on opcodes with no
 // parameters. Add a space on the end here incase there wasn't one already.
-#define @emit%0\32;%1\10;%3 asm_emit_(ctx,%1 );
+#define @emit%0\32;%1\10;%3 (asm_emit_label:asm_emit_notlabel:asm_emit_(ctx,%1));
+
+// Detect labels (for jump targets).
+#define asm_emit_label:asm_emit_notlabel:asm_emit_(ctx,%1:) AsmEmitLabel(ctx,#%1)
+#define asm_emit_notlabel:asm_emit_(ctx,%1) asm_emit_(ctx,%1 )
+
+// Detect jumps to labels, instead of the labels themselves.
+#define AsmEmitLabel(ctx,#%1\32;%2) asm_emit_%1Label(ctx,#%2)
+
 // NOW detect the second space and use it to extract the opcode name.
 #define asm_emit_(ctx,%1\32;%2) asm_emit_%1(ctx,%2)
+
 // Finally, detect zero parameters.
 #define ctx,) ctx)
 
@@ -554,3 +563,130 @@
 #define asm_emit_SREF AsmEmitSref
 #define asm_emit_STRB AsmEmitStrb
 #define asm_emit_SWAP AsmEmitSwap
+
+// Jumps to labels.
+#define asm_emit_jeqLabel AsmEmitJeqLabel
+#define asm_emit_jeq_labelLabel AsmEmitJeqLabel
+#define asm_emit_jgeqLabel AsmEmitJgeqLabel
+#define asm_emit_jgeq_labelLabel AsmEmitJgeqLabel
+#define asm_emit_jgrtrLabel AsmEmitJgrtrLabel
+#define asm_emit_jgrtr_labelLabel AsmEmitJgrtrLabel
+#define asm_emit_jleqLabel AsmEmitJleqLabel
+#define asm_emit_jleq_labelLabel AsmEmitJleqLabel
+#define asm_emit_jlessLabel AsmEmitJlessLabel
+#define asm_emit_jless_labelLabel AsmEmitJlessLabel
+#define asm_emit_jneqLabel AsmEmitJneqLabel
+#define asm_emit_jneq_labelLabel AsmEmitJneqLabel
+#define asm_emit_jnzLabel AsmEmitJnzLabel
+#define asm_emit_jnz_labelLabel AsmEmitJnzLabel
+#define asm_emit_jsgeqLabel AsmEmitJsgeqLabel
+#define asm_emit_jsgeq_labelLabel AsmEmitJsgeqLabel
+#define asm_emit_jsgrtrLabel AsmEmitJsgrtrLabel
+#define asm_emit_jsgrtr_labelLabel AsmEmitJsgrtrLabel
+#define asm_emit_jsleqLabel AsmEmitJsleqLabel
+#define asm_emit_jsleq_labelLabel AsmEmitJsleqLabel
+#define asm_emit_jslessLabel AsmEmitJslessLabel
+#define asm_emit_jsless_labelLabel AsmEmitJslessLabel
+#define asm_emit_jumpLabel AsmEmitJumpLabel
+#define asm_emit_jump_labelLabel AsmEmitJumpLabel
+#define asm_emit_jzerLabel AsmEmitJzerLabel
+#define asm_emit_jzer_labelLabel AsmEmitJzerLabel
+
+#define asm_emit_jeq_label(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
+#define asm_emit_jgeq_label(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
+#define asm_emit_jgrtr_label(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
+#define asm_emit_jleq_label(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
+#define asm_emit_jless_label(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
+#define asm_emit_jneq_label(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
+#define asm_emit_jnz_label(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
+#define asm_emit_jsgeq_label(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
+#define asm_emit_jsgrtr_label(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
+#define asm_emit_jsleq_label(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
+#define asm_emit_jsless_label(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
+#define asm_emit_jump_label(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
+#define asm_emit_jzer_label(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
+
+#define asm_emit_JEQLabel AsmEmitJeqLabel
+#define asm_emit_JGEQLabel AsmEmitJgeqLabel
+#define asm_emit_JGRTRLabel AsmEmitJgrtrLabel
+#define asm_emit_JLEQLabel AsmEmitJleqLabel
+#define asm_emit_JLESSLabel AsmEmitJlessLabel
+#define asm_emit_JNEQLabel AsmEmitJneqLabel
+#define asm_emit_JNZLabel AsmEmitJnzLabel
+#define asm_emit_JSGEQLabel AsmEmitJsgeqLabel
+#define asm_emit_JSGRTRLabel AsmEmitJsgrtrLabel
+#define asm_emit_JSLEQLabel AsmEmitJsleqLabel
+#define asm_emit_JSLESSLabel AsmEmitJslessLabel
+#define asm_emit_JUMPLabel AsmEmitJumpLabel
+#define asm_emit_JZERLabel AsmEmitJzerLabel
+
+#define asm_emit_JeqLabel AsmEmitJeqLabel
+#define asm_emit_JgeqLabel AsmEmitJgeqLabel
+#define asm_emit_JgrtrLabel AsmEmitJgrtrLabel
+#define asm_emit_JleqLabel AsmEmitJleqLabel
+#define asm_emit_JlessLabel AsmEmitJlessLabel
+#define asm_emit_JneqLabel AsmEmitJneqLabel
+#define asm_emit_JnzLabel AsmEmitJnzLabel
+#define asm_emit_JsgeqLabel AsmEmitJsgeqLabel
+#define asm_emit_JsgrtrLabel AsmEmitJsgrtrLabel
+#define asm_emit_JsleqLabel AsmEmitJsleqLabel
+#define asm_emit_JslessLabel AsmEmitJslessLabel
+#define asm_emit_JumpLabel AsmEmitJumpLabel
+#define asm_emit_JzerLabel AsmEmitJzerLabel
+
+// Only used when they explicitly typed `@emit JUMP.label x`
+#define AsmEmitJeqlabel(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
+#define AsmEmitJgeqlabel(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
+#define AsmEmitJgrtrlabel(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
+#define AsmEmitJleqlabel(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
+#define AsmEmitJlesslabel(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
+#define AsmEmitJneqlabel(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
+#define AsmEmitJnzlabel(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
+#define AsmEmitJsgeqlabel(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
+#define AsmEmitJsgrtrlabel(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
+#define AsmEmitJsleqlabel(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
+#define AsmEmitJslesslabel(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
+#define AsmEmitJumplabel(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
+#define AsmEmitJzerlabel(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
+#define AsmEmitJeqLABEL(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
+#define AsmEmitJgeqLABEL(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
+#define AsmEmitJgrtrLABEL(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
+#define AsmEmitJleqLABEL(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
+#define AsmEmitJlessLABEL(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
+#define AsmEmitJneqLABEL(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
+#define AsmEmitJnzLABEL(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
+#define AsmEmitJsgeqLABEL(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
+#define AsmEmitJsgrtrLABEL(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
+#define AsmEmitJsleqLABEL(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
+#define AsmEmitJslessLABEL(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
+#define AsmEmitJumpLABEL(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
+#define AsmEmitJzerLABEL(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
+
+// Only used when they explicitly typed `@emit JUMP.label x:`
+#define AsmEmitJeqlabelLabel AsmEmitJeqLabel
+#define AsmEmitJgeqlabelLabel AsmEmitJgeqLabel
+#define AsmEmitJgrtrlabelLabel AsmEmitJgrtrLabel
+#define AsmEmitJleqlabelLabel AsmEmitJleqLabel
+#define AsmEmitJlesslabelLabel AsmEmitJlessLabel
+#define AsmEmitJneqlabelLabel AsmEmitJneqLabel
+#define AsmEmitJnzlabelLabel AsmEmitJnzLabel
+#define AsmEmitJsgeqlabelLabel AsmEmitJsgeqLabel
+#define AsmEmitJsgrtrlabelLabel AsmEmitJsgrtrLabel
+#define AsmEmitJsleqlabelLabel AsmEmitJsleqLabel
+#define AsmEmitJslesslabelLabel AsmEmitJslessLabel
+#define AsmEmitJumplabelLabel AsmEmitJumpLabel
+#define AsmEmitJzerlabelLabel AsmEmitJzerLabel
+#define AsmEmitJeqLABELLabel AsmEmitJeqLabel
+#define AsmEmitJgeqLABELLabel AsmEmitJgeqLabel
+#define AsmEmitJgrtrLABELLabel AsmEmitJgrtrLabel
+#define AsmEmitJleqLABELLabel AsmEmitJleqLabel
+#define AsmEmitJlessLABELLabel AsmEmitJlessLabel
+#define AsmEmitJneqLABELLabel AsmEmitJneqLabel
+#define AsmEmitJnzLABELLabel AsmEmitJnzLabel
+#define AsmEmitJsgeqLABELLabel AsmEmitJsgeqLabel
+#define AsmEmitJsgrtrLABELLabel AsmEmitJsgrtrLabel
+#define AsmEmitJsleqLABELLabel AsmEmitJsleqLabel
+#define AsmEmitJslessLABELLabel AsmEmitJslessLabel
+#define AsmEmitJumpLABELLabel AsmEmitJumpLabel
+#define AsmEmitJzerLABELLabel AsmEmitJzerLabel
+

--- a/asm_macros.inc
+++ b/asm_macros.inc
@@ -32,7 +32,7 @@
 #define asm_emit_notlabel:asm_emit_(ctx,%1) asm_emit_(ctx,%1 )
 
 // Detect jumps to labels, instead of the labels themselves.
-#define AsmEmitLabel(ctx,#%1\32;%2) asm_emit_%1Label(ctx,#%2)
+#define AsmEmitLabel(ctx,#%1\32;%2) asm_emit_%1Label(ctx,%2)
 
 // NOW detect the second space and use it to extract the opcode name.
 #define asm_emit_(ctx,%1\32;%2) asm_emit_%1(ctx,%2)
@@ -592,19 +592,19 @@
 #define asm_emit_jzerLabel AsmEmitJzerLabel
 #define asm_emit_jzer_labelLabel AsmEmitJzerLabel
 
-#define asm_emit_jeq_label(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
-#define asm_emit_jgeq_label(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
-#define asm_emit_jgrtr_label(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
-#define asm_emit_jleq_label(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
-#define asm_emit_jless_label(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
-#define asm_emit_jneq_label(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
-#define asm_emit_jnz_label(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
-#define asm_emit_jsgeq_label(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
-#define asm_emit_jsgrtr_label(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
-#define asm_emit_jsleq_label(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
-#define asm_emit_jsless_label(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
-#define asm_emit_jump_label(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
-#define asm_emit_jzer_label(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
+#define asm_emit_jeq_label AsmEmitJeqLabel
+#define asm_emit_jgeq_label AsmEmitJgeqLabel
+#define asm_emit_jgrtr_label AsmEmitJgrtrLabel
+#define asm_emit_jleq_label AsmEmitJleqLabel
+#define asm_emit_jless_label AsmEmitJlessLabel
+#define asm_emit_jneq_label AsmEmitJneqLabel
+#define asm_emit_jnz_label AsmEmitJnzLabel
+#define asm_emit_jsgeq_label AsmEmitJsgeqLabel
+#define asm_emit_jsgrtr_label AsmEmitJsgrtrLabel
+#define asm_emit_jsleq_label AsmEmitJsleqLabel
+#define asm_emit_jsless_label AsmEmitJslessLabel
+#define asm_emit_jump_label AsmEmitJumpLabel
+#define asm_emit_jzer_label AsmEmitJzerLabel
 
 #define asm_emit_JEQLabel AsmEmitJeqLabel
 #define asm_emit_JGEQLabel AsmEmitJgeqLabel
@@ -635,32 +635,52 @@
 #define asm_emit_JzerLabel AsmEmitJzerLabel
 
 // Only used when they explicitly typed `@emit JUMP.label x`
-#define AsmEmitJeqlabel(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
-#define AsmEmitJgeqlabel(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
-#define AsmEmitJgrtrlabel(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
-#define AsmEmitJleqlabel(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
-#define AsmEmitJlesslabel(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
-#define AsmEmitJneqlabel(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
-#define AsmEmitJnzlabel(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
-#define AsmEmitJsgeqlabel(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
-#define AsmEmitJsgrtrlabel(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
-#define AsmEmitJsleqlabel(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
-#define AsmEmitJslesslabel(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
-#define AsmEmitJumplabel(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
-#define AsmEmitJzerlabel(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
-#define AsmEmitJeqLABEL(ctx,%2) AsmEmitJeqLabel(ctx,#%2)
-#define AsmEmitJgeqLABEL(ctx,%2) AsmEmitJgeqLabel(ctx,#%2)
-#define AsmEmitJgrtrLABEL(ctx,%2) AsmEmitJgrtrLabel(ctx,#%2)
-#define AsmEmitJleqLABEL(ctx,%2) AsmEmitJleqLabel(ctx,#%2)
-#define AsmEmitJlessLABEL(ctx,%2) AsmEmitJlessLabel(ctx,#%2)
-#define AsmEmitJneqLABEL(ctx,%2) AsmEmitJneqLabel(ctx,#%2)
-#define AsmEmitJnzLABEL(ctx,%2) AsmEmitJnzLabel(ctx,#%2)
-#define AsmEmitJsgeqLABEL(ctx,%2) AsmEmitJsgeqLabel(ctx,#%2)
-#define AsmEmitJsgrtrLABEL(ctx,%2) AsmEmitJsgrtrLabel(ctx,#%2)
-#define AsmEmitJsleqLABEL(ctx,%2) AsmEmitJsleqLabel(ctx,#%2)
-#define AsmEmitJslessLABEL(ctx,%2) AsmEmitJslessLabel(ctx,#%2)
-#define AsmEmitJumpLABEL(ctx,%2) AsmEmitJumpLabel(ctx,#%2)
-#define AsmEmitJzerLABEL(ctx,%2) AsmEmitJzerLabel(ctx,#%2)
+#define AsmEmitJeqlabel AsmEmitJeqLabel
+#define AsmEmitJgeqlabel AsmEmitJgeqLabel
+#define AsmEmitJgrtrlabel AsmEmitJgrtrLabel
+#define AsmEmitJleqlabel AsmEmitJleqLabel
+#define AsmEmitJlesslabel AsmEmitJlessLabel
+#define AsmEmitJneqlabel AsmEmitJneqLabel
+#define AsmEmitJnzlabel AsmEmitJnzLabel
+#define AsmEmitJsgeqlabel AsmEmitJsgeqLabel
+#define AsmEmitJsgrtrlabel AsmEmitJsgrtrLabel
+#define AsmEmitJsleqlabel AsmEmitJsleqLabel
+#define AsmEmitJslesslabel AsmEmitJslessLabel
+#define AsmEmitJumplabel AsmEmitJumpLabel
+#define AsmEmitJzerlabel AsmEmitJzerLabel
+
+#define AsmEmitJeqLABEL AsmEmitJeqLabel
+#define AsmEmitJgeqLABEL AsmEmitJgeqLabel
+#define AsmEmitJgrtrLABEL AsmEmitJgrtrLabel
+#define AsmEmitJleqLABEL AsmEmitJleqLabel
+#define AsmEmitJlessLABEL AsmEmitJlessLabel
+#define AsmEmitJneqLABEL AsmEmitJneqLabel
+#define AsmEmitJnzLABEL AsmEmitJnzLabel
+#define AsmEmitJsgeqLABEL AsmEmitJsgeqLabel
+#define AsmEmitJsgrtrLABEL AsmEmitJsgrtrLabel
+#define AsmEmitJsleqLABEL AsmEmitJsleqLabel
+#define AsmEmitJslessLABEL AsmEmitJslessLabel
+#define AsmEmitJumpLABEL AsmEmitJumpLabel
+#define AsmEmitJzerLABEL AsmEmitJzerLabel
+
+// This is required as otherwise:
+//   
+//   @emit Jump.Label x
+//   
+// Would not generate the `#x` required, while all other versions would.
+#define AsmEmitJeqLabel(ctx,%2) AsmEmitJeqLabelStringize(ctx,#%2)
+#define AsmEmitJgeqLabel(ctx,%2) AsmEmitJgeqLabelStringize(ctx,#%2)
+#define AsmEmitJgrtrLabel(ctx,%2) AsmEmitJgrtrLabelStringize(ctx,#%2)
+#define AsmEmitJleqLabel(ctx,%2) AsmEmitJleqLabelStringize(ctx,#%2)
+#define AsmEmitJlessLabel(ctx,%2) AsmEmitJlessLabelStringize(ctx,#%2)
+#define AsmEmitJneqLabel(ctx,%2) AsmEmitJneqLabelStringize(ctx,#%2)
+#define AsmEmitJnzLabel(ctx,%2) AsmEmitJnzLabelStringize(ctx,#%2)
+#define AsmEmitJsgeqLabel(ctx,%2) AsmEmitJsgeqLabelStringize(ctx,#%2)
+#define AsmEmitJsgrtrLabel(ctx,%2) AsmEmitJsgrtrLabelStringize(ctx,#%2)
+#define AsmEmitJsleqLabel(ctx,%2) AsmEmitJsleqLabelStringize(ctx,#%2)
+#define AsmEmitJslessLabel(ctx,%2) AsmEmitJslessLabelStringize(ctx,#%2)
+#define AsmEmitJumpLabel(ctx,%2) AsmEmitJumpLabelStringize(ctx,#%2)
+#define AsmEmitJzerLabel(ctx,%2) AsmEmitJzerLabelStringize(ctx,#%2)
 
 // Only used when they explicitly typed `@emit JUMP.label x:`
 #define AsmEmitJeqlabelLabel AsmEmitJeqLabel
@@ -676,6 +696,7 @@
 #define AsmEmitJslesslabelLabel AsmEmitJslessLabel
 #define AsmEmitJumplabelLabel AsmEmitJumpLabel
 #define AsmEmitJzerlabelLabel AsmEmitJzerLabel
+
 #define AsmEmitJeqLABELLabel AsmEmitJeqLabel
 #define AsmEmitJgeqLABELLabel AsmEmitJgeqLabel
 #define AsmEmitJgrtrLABELLabel AsmEmitJgrtrLabel
@@ -689,4 +710,31 @@
 #define AsmEmitJslessLABELLabel AsmEmitJslessLabel
 #define AsmEmitJumpLABELLabel AsmEmitJumpLabel
 #define AsmEmitJzerLABELLabel AsmEmitJzerLabel
+
+#define AsmEmitJeqLabelLabel AsmEmitJeqLabel
+#define AsmEmitJgeqLabelLabel AsmEmitJgeqLabel
+#define AsmEmitJgrtrLabelLabel AsmEmitJgrtrLabel
+#define AsmEmitJleqLabelLabel AsmEmitJleqLabel
+#define AsmEmitJlessLabelLabel AsmEmitJlessLabel
+#define AsmEmitJneqLabelLabel AsmEmitJneqLabel
+#define AsmEmitJnzLabelLabel AsmEmitJnzLabel
+#define AsmEmitJsgeqLabelLabel AsmEmitJsgeqLabel
+#define AsmEmitJsgrtrLabelLabel AsmEmitJsgrtrLabel
+#define AsmEmitJsleqLabelLabel AsmEmitJsleqLabel
+#define AsmEmitJslessLabelLabel AsmEmitJslessLabel
+#define AsmEmitJumpLabelLabel AsmEmitJumpLabel
+#define AsmEmitJzerLabelLabel AsmEmitJzerLabel
+
+// CallLabel macros.
+#define asm_emit_callLabel AsmEmitCallLabel
+#define asm_emit_call_labelLabel AsmEmitCallLabel
+#define asm_emit_call_label AsmEmitCallLabel
+#define asm_emit_CALLLabel AsmEmitCallLabel
+#define asm_emit_CallLabel AsmEmitCallLabel
+#define AsmEmitCalllabel AsmEmitCallLabel
+#define AsmEmitCallLABEL AsmEmitCallLabel
+#define AsmEmitCalllabelLabel AsmEmitCallLabel
+#define AsmEmitCallLABELLabel AsmEmitCallLabel
+#define AsmEmitCallLabelLabel AsmEmitCallLabel
+#define AsmEmitCallLabel(ctx,%2) AsmEmitCallLabelStringize(ctx,#%2)
 

--- a/codescan.inc
+++ b/codescan.inc
@@ -545,6 +545,7 @@ static stock bool:CodeScanStepInternal(dctx[DisasmContext], csState[CodeScanner]
 				// be missing if there are no variables currently in scope.
 				case OP_LCTRL: {
 					if (DisasmGetOperand(dctx) == 5) {
+						parseParam = 0;
 						parseState = 1;
 					} else {
 						parseState = 0;

--- a/codescan.inc
+++ b/codescan.inc
@@ -69,6 +69,7 @@ stock MyFunc(a, b[], ...)
 #include "frame_info"
 #include "disasm"
 #include "asm"
+#include "addressof"
 
 #define SCANNER_FAIL_ON_INVALID (1)
 #define SCANNER_IGNORE_NOP      (2)
@@ -138,19 +139,6 @@ stock MyFunc(a, b[], ...)
 #define O@2_:%9$%0&%1|||%2)   O@F_),(O@A_()?(((CALL@%1),O@V_)?1:2):_:O@X_:O@Y_:O@Z_:$(O@V_)%2)
 #define O@3_:%9$%1|||%2)      O@I_ ),(_:O@X_:O@Y_:O@Z_:$(%1)%2)
 
-// This code uses two nested conditionals because of:
-// https://github.com/Zeex/pawn/issues/96 (this doesn't work):
-//   
-//   (O@A_() ? ((CALL@%1), 0) : (O@V_))
-//   
-// Even though it is the obvious solution when you don't want the result of
-// "CALL@%1" to be used (as it may not exist), and you can't use a constant
-// instead of "O@V_" because then if becomes a constant in a
-// condition, which the compiler rightly complains about.  Of course, because
-// "O@A_()" always returns "false", the entire other block of code
-// is jumped over.
-#define addressof(%1) (O@A_()?(((CALL@%1),O@V_)?1:2):(O@V_))
-
 #if !defined cellbytes
 	#define cellbytes (cellbits / 8)
 #endif
@@ -195,41 +183,18 @@ enum CodeScanMatcher {
 	CodeScanMatcher_flags      // Customisation.
 }
 
-#define gCodeScanReturnVar_ O@V_
-#define CodeScanGetNextCall_ O@A_
-#define CALL@CodeScanGetNextCall_ CALL@O@A_
-#define CALL@O@A_ O@A_()
-
 // This macro is to let anyone use `&callback` for a scanner callback without
 // having to define the `CALL@...` macro for the required parameters (since we
 // know to call scanner callbacks in this code).
 #define addressof_ScannerCallback_(%1) (O@A_()?(((%1((gCodeScanCallback_match))),O@V_)?1:2):(O@V_))
 
 stock
-	gCodeScanReturnVar_ = 0,
 	gCodeScanCallback_match[CodeScanner];
 
 static stock
 	gHdr[AMX_HDR],
 	gBase,
 	gDat;
-
-stock bool:CodeScanGetNextCall_() {
-	// Start reading code from the point to which this function returns, looking
-	// for the next "CALL" op to signal the function call from the macro.
-	new ctx[DisasmContext];
-	DisasmInit(ctx, GetCurrentFrameReturn());
-	while (DisasmNext(ctx)) {
-		if (DisasmGetOpcode(ctx) == OP_CALL) {
-			// Return the data in a global, to be repassed from the conditional.
-			gCodeScanReturnVar_ = DisasmGetOperandReloc(ctx);
-			return false;
-		}
-	}
-	// ALWAYS returns false so that the function call within "OP(&func)" will
-	// never be called thanks to the conditional.
-	return false;
-}
 
 static stock CodeScanReset(cs[CodeScanMatcher], &next) {
 	static

--- a/codescan.inc
+++ b/codescan.inc
@@ -165,10 +165,6 @@ stock MyFunc(a, b[], ...)
 	#define CODE_SCAN_MAX_PARALLEL (2)
 #endif
 
-#if !defined CODE_SCAN_MAX_JUMP_TARGETS
-	#define CODE_SCAN_MAX_JUMP_TARGETS (32)
-#endif
-
 // All the information for scanning through an AMX and extracting lots of nice
 // information about it.
 enum CodeScanner {
@@ -182,11 +178,6 @@ enum CodeScanner {
 	CodeScanMatch_holes[CODE_SCAN_MAX_HOLES], // Results of "???"s.
 	CodeScanMatch_name[32 char],
 	CodeScanner_first,
-	CodeScanner_minn,
-	CodeScanner_jump_switch[CODE_SCAN_MAX_JUMP_TARGETS], // For "CASETBL" not regular jumps.
-	CodeScanner_jump_target[CODE_SCAN_MAX_JUMP_TARGETS], // Zero when this slot is available.
-	CodeScanner_jump_stack [CODE_SCAN_MAX_JUMP_TARGETS], // Sizes at the time of the jump.
-	CodeScanner_jump_heap  [CODE_SCAN_MAX_JUMP_TARGETS], // Sizes at the time of the jump.
 	CodeScanner_state,
 	CodeScanner_param
 }
@@ -238,90 +229,6 @@ stock bool:CodeScanGetNextCall_() {
 	// ALWAYS returns false so that the function call within "OP(&func)" will
 	// never be called thanks to the conditional.
 	return false;
-}
-
-static stock bool:CodeScanCheckJumpTarget(cip, deloc, &stk, &hea, jumpTargets[CodeScanner], num = CODE_SCAN_MAX_JUMP_TARGETS)
-{
-	// Use "minn" to restrict the number of jump targets that we check.  Returns
-	// "true" if the current address is equal to an address that any jump goes
-	// to.
-	new
-		minn = jumpTargets[CodeScanner_minn],
-		sip,
-		count;
-	while (num-- > minn) {
-		if (jumpTargets[CodeScanner_jump_target][num]) {
-			if ((sip = jumpTargets[CodeScanner_jump_switch][num])) {
-				count = ReadAmxMemory(sip) + 1,
-				sip += cellbytes;
-				while (count--) {
-					if (ReadAmxMemory(sip) == deloc) {
-						return
-							--jumpTargets[CodeScanner_jump_target][num],
-							stk = jumpTargets[CodeScanner_jump_stack][num],
-							hea = jumpTargets[CodeScanner_jump_heap][num],
-							true;
-					}
-					sip += 2 * cellbytes;
-				}
-			} else if (jumpTargets[CodeScanner_jump_target][num] == cip) {
-				return
-					jumpTargets[CodeScanner_jump_target][num] = 0,
-					stk = jumpTargets[CodeScanner_jump_stack][num],
-					hea = jumpTargets[CodeScanner_jump_heap][num],
-					true;
-			}
-		}
-	}
-	return false;
-}
-
-static stock CodeScanResetJumpTargets(jumpTargets[CodeScanner], num = CODE_SCAN_MAX_JUMP_TARGETS)
-{
-	jumpTargets[CodeScanner_minn] = num;
-	while (num--) {
-		jumpTargets[CodeScanner_jump_target][num] = 0;
-	}
-}
-
-static stock CodeScanAddJumpTarget(cip, stk, hea, jumpTargets[CodeScanner], num = CODE_SCAN_MAX_JUMP_TARGETS)
-{
-	while (num--) {
-		// Multiple jumps to the same place?
-		if (jumpTargets[CodeScanner_jump_target][num] == cip) {
-			return;
-		} else if (!jumpTargets[CodeScanner_jump_target][num]) {
-			jumpTargets[CodeScanner_jump_switch][num] = 0;
-			jumpTargets[CodeScanner_jump_target][num] = cip;
-			jumpTargets[CodeScanner_jump_stack][num] = stk;
-			jumpTargets[CodeScanner_jump_heap][num] = hea;
-			jumpTargets[CodeScanner_minn] = min(jumpTargets[CodeScanner_minn], num);
-			return;
-		}
-	}
-}
-
-static stock CodeScanAddSwitchTarget(dctx[DisasmContext], stk, hea, jumpTargets[CodeScanner], num = CODE_SCAN_MAX_JUMP_TARGETS)
-{
-	new
-		sip = DisasmGetOperand(dctx) - gBase,
-		codepos = sip + gHdr[AMX_HDR_DAT] - gHdr[AMX_HDR_COD];
-	if (codepos < 0 || codepos > gHdr[AMX_HDR_DAT] || UnrelocateOpcode(Opcode:ReadAmxMemory(sip)) != OP_CASETBL) {
-		// Can happen when we parse "RelocateOpcodeNow" because it has an
-		// explicit "#emit switch 0" in.
-		return;
-	}
-	while (num--) {
-		// Multiple jumps to the same place?
-		if (!jumpTargets[CodeScanner_jump_target][num]) {
-			jumpTargets[CodeScanner_jump_switch][num] = sip + cellbytes,
-			jumpTargets[CodeScanner_jump_target][num] = ReadAmxMemory(sip + cellbytes) + 1,
-			jumpTargets[CodeScanner_jump_stack][num] = stk,
-			jumpTargets[CodeScanner_jump_heap][num] = hea,
-			jumpTargets[CodeScanner_minn] = min(jumpTargets[CodeScanner_minn], num);
-			return;
-		}
-	}
 }
 
 static stock CodeScanReset(cs[CodeScanMatcher], &next) {
@@ -560,14 +467,12 @@ static stock bool:CodeScanStepInternal(dctx[DisasmContext], csState[CodeScanner]
 				Opcode:op = DisasmGetOpcode(dctx);
 			// The compiler sometimes inserts extra instructions like "NOP" and
 			// "BREAK" for debugging and padding (as do we) - maybe ignore them.
-			CodeScanCheckJumpTarget(cip, cip + gBase, stk, hea, csState);
 			switch (op) {
 				case OP_HALT: {
 					if (parseState == 4) {
 						csState[CodeScanMatch_type] = SCANNER_FUNC_HALT_NO_NAME,
 						csState[CodeScanMatch_func] = cip,
-						stk = hea = 0,
-						CodeScanResetJumpTargets(csState);
+						stk = hea = 0;
 					}
 				}
 				case OP_PROC: {
@@ -575,7 +480,6 @@ static stock bool:CodeScanStepInternal(dctx[DisasmContext], csState[CodeScanner]
 					// that don't start like this are the automata stubs.
 					csState[CodeScanMatch_type] = SCANNER_FUNC_UNKNOWN,
 					csState[CodeScanMatch_func] = cip,
-					CodeScanResetJumpTargets(csState),
 					stk = hea = parseState = 0;
 				}
 				case OP_LOAD_PRI: {
@@ -585,8 +489,7 @@ static stock bool:CodeScanStepInternal(dctx[DisasmContext], csState[CodeScanner]
 					if (parseState == 4) {
 						csState[CodeScanMatch_type] = SCANNER_FUNC_AUTOMATA_NO_NAME,
 						csState[CodeScanMatch_func] = cip,
-						stk = hea = 0,
-						CodeScanResetJumpTargets(csState);
+						stk = hea = 0;
 					}
 				}
 				case OP_PUSH_PRI, OP_PUSH_ALT, OP_PUSH_R, OP_PUSH_S, OP_PUSH, OP_PUSH_ADR: {
@@ -682,41 +585,6 @@ static stock bool:CodeScanStepInternal(dctx[DisasmContext], csState[CodeScanner]
 					}
 					parseState = 0;
 				}
-				case OP_JUMP, OP_JZER, OP_JNZ, OP_JEQ, OP_JNEQ, OP_JLESS, OP_JLEQ, OP_JGRTR, OP_JGEQ, OP_JSLESS, OP_JSLEQ, OP_JSGRTR, OP_JSGEQ: {
-					// Add a jump target.  These require relocation as they are
-					// translated to absolute RAM locations.  "DisasmNeedReloc"
-					// will return "true", but we don't need to call it.
-					// Relocate it relative to "dat" not "cod" for simpler
-					// comparisons - just see if the read address matches
-					// instead of the true code address.
-					//   
-					//   val = val - (base + cod) + (cod - dat);
-					//   val = val - base - cod + cod - dat;
-					//   val = val - base - dat;
-					//   val = val - (base + dat);
-					//   base = base + dat;
-					//   val = val - base;
-					//   
-					// Only jumps that go forwards.
-					parseParam = DisasmGetOperand(dctx) - gBase,
-					parseState = 0;
-					if (parseParam > cip) {
-						CodeScanAddJumpTarget(parseParam, stk, hea, csState);
-					}
-				}
-				case OP_JREL: {
-					// Add a jump target.  Only jumps that go forwards.
-					parseParam = DisasmGetOperand(dctx) + cip,
-					parseState = 0;
-					if (parseParam > cip) {
-						CodeScanAddJumpTarget(parseParam, stk, hea, csState);
-					}
-				}
-				case OP_SWITCH: {
-					// Add a jump target.  These are always forwards.
-					CodeScanAddSwitchTarget(dctx, stk, hea, csState),
-					parseState = 0;
-				}
 				default: {
 					parseState = 0;
 				}
@@ -787,9 +655,6 @@ stock bool:CodeScanRun(csState[CodeScanner]) {
 	DisasmInit(dctx);
 	for (cur = csState[CodeScanner_first]; cur != -1; CodeScanReset(CodeScanDeref(cur), cur)) { }
 	while (CodeScanStepInternal(dctx, csState, parseState, parseParam)) {
-		// Check the address - if it is a jump target that changes the stack
-		// size BEFORE the instruction, while the instruction itself changes
-		// it after.
 		// Found a valid instruction that we don't want to ignore.  Finally
 		// do the actual comparisons to various defined scanners.
 		for (cur = csState[CodeScanner_first], op = DisasmGetOpcode(dctx); cur != -1; ) {
@@ -825,7 +690,6 @@ stock CodeScanInit(scanner[CodeScanner]) {
 	GetAmxHeader(gHdr),
 	gBase = GetAmxBaseAddress() + gHdr[AMX_HDR_DAT],
 	gDat = gHdr[AMX_HDR_COD] - gHdr[AMX_HDR_DAT],
-	CodeScanResetJumpTargets(scanner),
 	scanner[CodeScanMatch_type] =
 	 scanner[CodeScanMatch_name] =
 	  scanner[CodeScanner_param] =
@@ -857,7 +721,7 @@ stock CodeScanGetMatchScanner(csm[CodeScanner], ret[CodeScanner], ctx[DisasmCont
 	// the currently found match.
 	CodeScanGetFunctionScanner(csm, ret, ctx);
 	if (accurate) {
-		// To be accurate in terms of jump targets, we re-run the scanner over
+		// To be accurate in terms of stack state, we re-run the scanner over
 		// the function back up to this point.
 		while (ctx[DisasmContext_nip] < csm[CodeScanMatch_cip]) {
 			CodeScanStepInternal(ctx, ret, ret[CodeScanner_state], ret[CodeScanner_param]);


### PR DESCRIPTION
Two major jump inprovements:

1) codescan.inc no longer keeps track of jumps for adjusting the stack.  This may seem like a downgrade, but emitted AMX code is designed to correct the stack to a constant size before/after a jump anyway, so there is no need to replicate this effort.  This change actually reduced one person's startup times using YSI from minutes to seconds (about a 60-fold improvement).

2) asm.inc now has basic labels:

```pawn
	@emit JUMP label_1:
	@emit JUMP label_1:
	@emit JUMP label_1:
	@emit JUMP label_1:
@emit label_1:
	@emit JUMP label_1:
	@emit JGEQ label_2:

@emit label_2:
	@emit JSLESS.Label label_2

@emit LABEL label_3
	@emit JUMP label_3:

@emit label label_4:
	@emit JUMP.label label_1
	@emit JUMP.label label_1
```

If an `@emit` line ends with `:`, it is assumed to be a label (colons elsewhere are still allowed).  You can also explicitly use `@emit Label` and no colon.

A `Jump` or `Call` opcode that ends with a colon is assumed to be a jump to that label.  Or again you can use `JUMP.label` or simlar without the colon.

