### PR TITLE
Fix #31

### DIFF
--- a/codescan.inc
+++ b/codescan.inc
@@ -218,6 +218,9 @@ static stock bool:CodeScanCheckJumpTarget(cip, deloc, &stk, &hea, jumpTargets[Co
 			stk = jumpTargets[CodeScanner_jump_stack][num],
 			hea = jumpTargets[CodeScanner_jump_heap][num];
 			return;
+		} else if (jumpTargets[CodeScanner_jump_target][num] < cip) {
+			jumpTargets[CodeScanner_minn] = num;
+			return;
 		}
 	}
 }


### PR DESCRIPTION
FINALLY figured out a way to correct the stack with much faster code:

1) The list of jump targets is now sorted, with the fast-path assuming that a new target is before existing targets (as they would be in nested code).

2) The stack update checks are only done after unconditional jumps.  This just never occurred to me before - it was checked at every instruction.  However, for normal instructions the stack size must be the same coming from the jump or the preceding code, thus there's no point checking.