### PR TITLE
Faster codescan.

### DIFF
--- a/addressof_jit.inc
+++ b/addressof_jit.inc
@@ -127,6 +127,6 @@ stock AddressofResolve() {
 	CodeScanAddMatcher(scanner, csm3);
 	
 	// Run the scanner.
-	CodeScanRun(scanner);
+	CodeScanRunFast(scanner, &AddressOfGetNextCall_);
 }
 

--- a/asm_macros.inc
+++ b/asm_macros.inc
@@ -500,6 +500,8 @@
 #define AsmEmitSysreq.%0(%1) AsmEmitSysreq%0(%1)
 #define AsmEmitSysreqc AsmEmitSysreqC
 #define AsmEmitSysreqd AsmEmitSysreqD
+#define AsmEmitSysreqpri AsmEmitSysreqPri
+#define AsmEmitSysreqPRI AsmEmitSysreqPri
 #define AsmEmitUdiv.%0(%1) AsmEmitUdiv%0(%1)
 #define AsmEmitUdivalt AsmEmitUdivAlt
 #define AsmEmitUdivALT AsmEmitUdivAlt

--- a/codescan.inc
+++ b/codescan.inc
@@ -774,6 +774,58 @@ static stock CodeScanCall(const cs[CodeScanMatcher], csState[CodeScanner]) {
 	return func;
 }
 
+static stock bool:CodeScanFindOneFastPattern3(const matcher[CodeScanMatcher], &addr, &cur) {
+	// Check if the current matcher has this exact function call in it as well.
+	cur = matcher[CodeScanMatcher_next];
+	for (new i = 0, j = matcher[CodeScanMatcher_len]; i != j; i += 2) {
+		if (matcher[CodeScanMatcher_code][i + 0] == OP_TYPE_OPCODE_ && Opcode:matcher[CodeScanMatcher_code][i + 1] == OP_CALL && matcher[CodeScanMatcher_code][i + 2] == OP_TYPE_FUNCTION_ && matcher[CodeScanMatcher_code][i + 3] == addr) {
+			return true;
+		}
+	}
+	return false;
+}
+
+static stock bool:CodeScanFindOneFastPattern2(const matcher[CodeScanMatcher], &addr) {
+	// Loop over all the function calls in the first matcher, and check that at least one exists in
+	// all the others.  We only need to loop over the first, because it must exist in them all, so
+	// even if it is in all but the first it isn't good enough.
+	for (new i = 0, j = matcher[CodeScanMatcher_len]; i != j; i += 2) {
+		if (matcher[CodeScanMatcher_code][i + 0] == OP_TYPE_OPCODE_ && Opcode:matcher[CodeScanMatcher_code][i + 1] == OP_CALL && matcher[CodeScanMatcher_code][i + 2] == OP_TYPE_FUNCTION_) {
+			// Found a candidate for the fast scan.
+			addr = matcher[CodeScanMatcher_code][i + 3];
+			new cur = matcher[CodeScanMatcher_next];
+			if (cur == -1) {
+				// There is only one matcher, so this function call will do.
+				return true;
+			}
+			do {
+				// Check that all other matchers have the same function call.
+				if (!CodeScanFindOneFastPattern3(CodeScanDeref(cur), addr, cur)) {
+					goto CodeScanFindOneFastPattern_fail;
+				}
+			}
+			while (cur != -1);
+			return true;
+		}
+CodeScanFindOneFastPattern_fail:
+	}
+	return false;
+}
+
+forward bool:CodeScanRun(csState[CodeScanner]);
+
+stock bool:CodeScanRunFast(csState[CodeScanner]) {
+	if (csState[CodeScanner_first] == -1) {
+		return true;
+	}
+	new addr;
+	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), addr))
+	{
+		printf("Found address: %08x", addr);
+	}
+	return CodeScanRun(csState);
+}
+
 stock bool:CodeScanRun(csState[CodeScanner]) {
 	if (csState[CodeScanner_first] == -1) {
 		return true;

--- a/codescan.inc
+++ b/codescan.inc
@@ -774,7 +774,7 @@ static stock CodeScanCall(const cs[CodeScanMatcher], csState[CodeScanner]) {
 	return func;
 }
 
-static stock bool:CodeScanFindOneFastPattern3(const matcher[CodeScanMatcher], &addr, &cur) {
+static stock bool:CodeScanFindOneFastPattern3(const matcher[CodeScanMatcher], addr, &cur) {
 	// Check if the current matcher has this exact function call in it as well.
 	cur = matcher[CodeScanMatcher_next];
 	for (new i = 0, j = matcher[CodeScanMatcher_len]; i != j; i += 2) {

--- a/codescan.inc
+++ b/codescan.inc
@@ -847,12 +847,11 @@ static stock CodeScanRunFastPrescan(&proc, &nextaddr, const searchFuncAddr) {
 	return false;
 }
 
-stock bool:CodeScanRunFast(csState[CodeScanner]) {
+stock bool:CodeScanRunFast(csState[CodeScanner], searchFuncAddr = 0) {
 	if (csState[CodeScanner_first] == -1) {
 		return true;
 	}
-	new searchFuncAddr;
-	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), searchFuncAddr)) {
+	if (searchFuncAddr || CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), searchFuncAddr)) {
 		new
 			proc,
 			addr = csState[CodeScanMatch_cip],
@@ -915,6 +914,8 @@ stock bool:CodeScanRunFast(csState[CodeScanner]) {
 		return CodeScanRun(csState);
 	}
 }
+
+#define CodeScanRunFast(%0,&%1) CodeScanRunFast(%0,addressof(%1))
 
 stock bool:CodeScanRun(csState[CodeScanner]) {
 	if (csState[CodeScanner_first] == -1) {

--- a/codescan.inc
+++ b/codescan.inc
@@ -203,7 +203,17 @@ static stock
 	gOP_CASETBL,
 	gHdr[AMX_HDR],
 	gBase,
+	gCodBase,
 	gDat;
+
+static stock const
+	gOpArgCount[Opcode:NUM_OPCODES] = {
+		4, 8, 8, 8, 8, 8, 8, 8, 8, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 4, 8, 4, 8, 4, 8, 8, 8,
+		8, 8, 4, 4, 4, 4, 4, 8, 8, 8, 8, 4, 4, 8, 8, 4, 4, 4, 8, 4, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+		8, 8, 8, 4, 4, 4, 8, 8, 8, 8, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 8, 8, 4, 4, 8, 8,
+		4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 8, 8, 4, 4, 8, 8, 4, 4, 4, 8, 8, 4, 8, 8, 8, 8, 8, 4, 8,
+		-1, -1, -1, -1, 4, 8, -1, 4, 4, 8, 4, 8, 8, 4
+	};
 
 static stock bool:CodeScanCheckJumpTarget(cip, deloc, &stk, &hea, jumpTargets[CodeScanner], num = CODE_SCAN_MAX_JUMP_TARGETS) {
 	// Use "minn" to restrict the number of jump targets that we check.  Returns
@@ -808,13 +818,53 @@ static stock bool:CodeScanFindOneFastPattern2(const matcher[CodeScanMatcher], &a
 
 forward bool:CodeScanRun(csState[CodeScanner]);
 
+static stock CodeScanRunFastInternal(&proc, &nextaddr, const searchFuncAddr) {
+	new Opcode:o;
+	new addr = nextaddr;
+	while (addr < 0) {
+		switch (o = UnrelocateOpcode(Opcode:ReadAmxMemory(addr))) {
+			case OP_PROC: {
+				proc = addr;
+				addr += 4;
+			}
+			case OP_CASETBL: {
+				addr += (2 * ReadAmxMemory(addr + 4) + 3) * 4;
+			}
+			case OP_CALL: {
+				if (ReadAmxMemory(addr + 4) - gCodBase == searchFuncAddr) {
+					nextaddr = addr;
+					return true;
+				}
+				addr += 8;
+			}
+			default: {
+				addr += gOpArgCount[o];
+			}
+		}
+	}
+	return false;
+}
+
 stock bool:CodeScanRunFast(csState[CodeScanner]) {
 	if (csState[CodeScanner_first] == -1) {
 		return true;
 	}
-	new addr;
-	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), addr)) {
-		printf("Found address: %08x", addr);
+	new searchFuncAddr;
+	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), searchFuncAddr)) {
+		new
+			proc,
+			addr = csState[CodeScanMatch_cip] - gDat + gDat;
+		while (CodeScanRunFastInternal(proc, addr, searchFuncAddr)) {
+			addr += 8;
+		}
+		
+		//count = gOpArgCount[cur];
+		//if (count == -1) {
+		//	count = /* read arg count */;
+		//}
+		//searchFuncAddr += count;
+		
+		
 	}
 	return CodeScanRun(csState);
 }
@@ -872,6 +922,7 @@ stock CodeScanInit(scanner[CodeScanner]) {
 	if (gDat == 0) {
 		GetAmxHeader(gHdr),
 		gBase = GetAmxBaseAddress() + gHdr[AMX_HDR_DAT],
+		gCodBase = GetAmxBaseAddress() + gHdr[AMX_HDR_COD],
 		gDat = gHdr[AMX_HDR_COD] - gHdr[AMX_HDR_DAT],
 		gOP_NOP = _:RelocateOpcode(OP_NOP);
 		gOP_CASETBL = _:RelocateOpcode(OP_CASETBL);

--- a/codescan.inc
+++ b/codescan.inc
@@ -865,7 +865,6 @@ stock bool:CodeScanRunFast(csState[CodeScanner]) {
 		// Enable scans to start at a non-zero position.
 		DisasmInit(dctx);
 		while (CodeScanRunFastPrescan(proc, addr, searchFuncAddr)) {
-			printf("found %08x %08x", proc, addr);
 			addr += 8,
 			second = false,
 			dctx[DisasmContext_nip] = proc;
@@ -912,6 +911,7 @@ stock bool:CodeScanRunFast(csState[CodeScanner]) {
 		}
 		return true;
 	} else {
+		printf("Could not find common `CALL <func>` for the common scanner.  Falling back to the slow scanner.");
 		return CodeScanRun(csState);
 	}
 }

--- a/codescan.inc
+++ b/codescan.inc
@@ -818,7 +818,9 @@ static stock bool:CodeScanFindOneFastPattern2(const matcher[CodeScanMatcher], &a
 
 forward bool:CodeScanRun(csState[CodeScanner]);
 
-static stock CodeScanRunFastInternal(&proc, &nextaddr, const searchFuncAddr) {
+static stock CodeScanRunFastPrescan(&proc, &nextaddr, const searchFuncAddr) {
+	// Do a fast code scan for functions containing something vaguely similar to the pattern.  Once
+	// that's found we can reparse the function with the full analysis mode.
 	new Opcode:o;
 	new addr = nextaddr;
 	while (addr < 0) {
@@ -853,20 +855,65 @@ stock bool:CodeScanRunFast(csState[CodeScanner]) {
 	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), searchFuncAddr)) {
 		new
 			proc,
-			addr = csState[CodeScanMatch_cip] - gDat + gDat;
-		while (CodeScanRunFastInternal(proc, addr, searchFuncAddr)) {
-			addr += 8;
+			addr = csState[CodeScanMatch_cip],
+			dctx[DisasmContext],
+			cur,
+			bool:second,
+			Opcode:op,
+			parseState = 4,
+			parseParam;
+		// Enable scans to start at a non-zero position.
+		DisasmInit(dctx);
+		while (CodeScanRunFastPrescan(proc, addr, searchFuncAddr)) {
+			printf("found %08x %08x", proc, addr);
+			addr += 8,
+			second = false,
+			dctx[DisasmContext_nip] = proc;
+			for (cur = csState[CodeScanner_first]; cur != -1; CodeScanReset(CodeScanDeref(cur), cur)) { }
+			while (CodeScanStepInternal(dctx, csState, parseState, parseParam)) {
+				if (second && dctx[DisasmContext_opcode] == OP_PROC) {
+					// Finished the function we know has relevant code in.  Move on.
+					addr = (proc = dctx[DisasmContext_cip]) + 4;
+					break;
+				}
+				second = true;
+				// Check the address - if it is a jump target that changes the stack
+				// size BEFORE the instruction, while the instruction itself changes
+				// it after.
+				// Found a valid instruction that we don't want to ignore.  Finally
+				// do the actual comparisons to various defined scanners.
+				for (cur = csState[CodeScanner_first], op = DisasmGetOpcode(dctx); cur != -1; ) {
+					if (CodeScanCheck(op, dctx, CodeScanDeref(cur), csState, cur)) {
+						switch (CodeScanCall(CodeScanDeref(cur), csState)) {
+							case cellmin: {
+								// End right now.
+								return true;
+							}
+							case -1: {
+								// Want to skip this match.  However, it was a full
+								// match so does need resetting.
+								CodeScanReset(CodeScanDeref(cur), cur);
+								continue;
+							}
+							case 0: {
+								// Do nothing except ignore.
+							}
+							default: {
+								// If code was written, reparse this function.
+								dctx[DisasmContext_nip] = proc;
+							}
+						}
+						// Reset to the start of the function, to reparse.
+						for (cur = csState[CodeScanner_first]; cur != -1; CodeScanReset(CodeScanDeref(cur), cur)) { }
+						break;
+					}
+				}
+			}
 		}
-		
-		//count = gOpArgCount[cur];
-		//if (count == -1) {
-		//	count = /* read arg count */;
-		//}
-		//searchFuncAddr += count;
-		
-		
+		return true;
+	} else {
+		return CodeScanRun(csState);
 	}
-	return CodeScanRun(csState);
 }
 
 stock bool:CodeScanRun(csState[CodeScanner]) {

--- a/codescan.inc
+++ b/codescan.inc
@@ -794,20 +794,14 @@ static stock bool:CodeScanFindOneFastPattern2(const matcher[CodeScanMatcher], &a
 			// Found a candidate for the fast scan.
 			addr = matcher[CodeScanMatcher_code][i + 3];
 			new cur = matcher[CodeScanMatcher_next];
-			if (cur == -1) {
-				// There is only one matcher, so this function call will do.
-				return true;
-			}
 			do {
-				// Check that all other matchers have the same function call.
-				if (!CodeScanFindOneFastPattern3(CodeScanDeref(cur), addr, cur)) {
-					goto CodeScanFindOneFastPattern_fail;
+				if (cur == -1) {
+					// Ran out of matchers, so this function call will do.
+					return true;
 				}
-			}
-			while (cur != -1);
-			return true;
+				// Check that all other matchers have the same function call.
+			} while (CodeScanFindOneFastPattern3(CodeScanDeref(cur), addr, cur));
 		}
-CodeScanFindOneFastPattern_fail:
 	}
 	return false;
 }
@@ -819,8 +813,7 @@ stock bool:CodeScanRunFast(csState[CodeScanner]) {
 		return true;
 	}
 	new addr;
-	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), addr))
-	{
+	if (CodeScanFindOneFastPattern2(CodeScanDeref(csState[CodeScanner_first]), addr)) {
 		printf("Found address: %08x", addr);
 	}
 	return CodeScanRun(csState);

--- a/disasm.inc
+++ b/disasm.inc
@@ -39,8 +39,7 @@ enum DisasmContext {
 	DisasmContext_end_ip,
 	DisasmContext_nip,
 	DisasmContext_cip,
-	Opcode:DisasmContext_opcode,
-	DisasmContext_insn[OpcodeInsnInfo]
+	Opcode:DisasmContext_opcode
 }
 
 enum DisasmResult {
@@ -93,7 +92,6 @@ stock bool:DisasmDecodeInsn(ctx[DisasmContext]) {
 
 	ctx[DisasmContext_cip] = ip;
 	ctx[DisasmContext_opcode] = opcode;
-	ctx[DisasmContext_insn] = GetOpcodeInstructionInformation(opcode);
 
 	ip += 4;
 
@@ -101,9 +99,8 @@ stock bool:DisasmDecodeInsn(ctx[DisasmContext]) {
 		new n = ReadAmxMemory(ip);
 		ip += 4;
 		ip += (2 * n + 1) * 4;
-		ctx[DisasmContext_insn][OpcodeInsnInfo_num_opers] = n;
 	} else {
-		ip += 4 * ctx[DisasmContext_insn][OpcodeInsnInfo_num_opers];
+		ip += 4 * GetOpcodeInstructionParameters(opcode);
 	}
 
 	ctx[DisasmContext_nip] = ip;
@@ -145,11 +142,17 @@ stock DisasmGetOperand(const ctx[DisasmContext], index = 0) {
 }
 
 stock DisasmGetNumOperands(const ctx[DisasmContext]) {
-	return ctx[DisasmContext_insn][OpcodeInsnInfo_num_opers];
+	new Opcode:opcode = ctx[DisasmContext_opcode];
+
+	if (opcode == OP_CASETBL) {
+		return ReadAmxMemory(ctx[DisasmContext_cip] + 4);
+	} else {
+		return GetOpcodeInstructionParameters(opcode);
+	}
 }
 
 stock bool:DisasmNeedReloc(const ctx[DisasmContext]) {
-	return ctx[DisasmContext_insn][OpcodeInsnInfo_needs_reloc];
+	return GetOpcodeInstructionRelocatable(ctx[DisasmContext_opcode]);
 }
 
 stock DisasmReloc(addr) {
@@ -170,7 +173,7 @@ stock DisasmGetRemaining(const ctx[DisasmContext]) {
 
 stock DisasmGetInsnName(const ctx[DisasmContext], name[], size = sizeof(name)) {
 	name[0] = '\0';
-	strcat(name, ctx[DisasmContext_insn][OpcodeInsnInfo_name], size);
+	strcat(name, GetOpcodeInstructionName(ctx[DisasmContext_opcode]), size);
 }
 
 stock DisasmGetOperandReloc(const ctx[DisasmContext], index = 0) {

--- a/opcode.inc
+++ b/opcode.inc
@@ -215,7 +215,7 @@ static stock const insn_table[][OpcodeInsnInfo] = {
 	{ "fill",        1, false },
 	{ "halt",        1, false },
 	{ "bounds",      1, false },
-	{ "sysreq.pri",  1, false },
+	{ "sysreq.pri",  0, false },
 	{ "sysreq.c",    1, false },
 	{ "file",       -1, false }, // obsolete
 	{ "line",       -1, false }, // obsolete


### PR DESCRIPTION
It now does some simple prescanning based on raw memory reading (i.e. without stack tracking etc) to find possible candidate code blocks.  Once those are found, re-runs the full scanner on those smaller sections.